### PR TITLE
inline functions for better compilation experience, add 'gzoffset,gzp…

### DIFF
--- a/izlib.h
+++ b/izlib.h
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <sys/stat.h>
-#include <isa-l/igzip_lib.h>
+#include "igzip_lib.h"
 
 #ifndef UNIX
 #define UNIX 3


### PR DESCRIPTION
- inline functions for better compilation experience

- add 'gzoffset,gzputs,gzputc,gzgets' functions with signatures same as zlib

- I have test them on plain gzip files and FASTQ gz files already, you'd better test them more throughly before merge and use it in production 